### PR TITLE
fix(storage): MariaDB compatibility (useInformationSchema=false)

### DIFF
--- a/server/src/main/kotlin/com/dreamdisplays/server/managers/StorageManager.kt
+++ b/server/src/main/kotlin/com/dreamdisplays/server/managers/StorageManager.kt
@@ -60,7 +60,7 @@ class DisplaysTable(prefix: String = "") : Table("${prefix}displays") {
     private val dataSource = HikariDataSource(HikariConfig().apply {
         jdbcUrl = when (type.uppercase()) {
             "SQLITE" -> "jdbc:sqlite:${File(dataDir, "dreamdisplays.db").absolutePath}"
-            "MYSQL" -> "jdbc:mysql://$host:$port/$database?autoReconnect=true&useSSL=false"
+            "MYSQL" -> "jdbc:mysql://$host:$port/$database?autoReconnect=true&useSSL=false&useInformationSchema=false"
             else -> error("Unsupported storage type: $type")
         }
         if (type.uppercase() != "SQLITE") {


### PR DESCRIPTION
## Problem
On MariaDB servers, enabling the plugin crashes during schema creation:

```
java.sql.SQLSyntaxErrorException: Unknown column 'RESERVED' in 'WHERE'
  at com.mysql.cj.jdbc.DatabaseMetaDataInformationSchema.getSQLKeywords(DatabaseMetaDataInformationSchema.java:983)
  at ...exposed...JdbcIdentifierManager.<init>
  at ...exposed...VendorDialect.tableExists
  at ...SchemaUtils.createMissingTablesAndColumns
  at com.dreamdisplays.server.managers.StorageManager.createSchema(StorageManager.kt:76)
```

## Root cause
`mysql-connector-j` (9.x) with `useInformationSchema=true` (its default for MySQL 8+) implements `getSQLKeywords()` by querying `information_schema.KEYWORDS` and filtering on the `RESERVED` column. That table/column is a **MySQL 8.0.11+** feature and does **not exist in any MariaDB version**. Exposed calls `getSQLKeywords()` while building the identifier manager during `tableExists()`, so plugin enable fails on MariaDB.

Not related to the server core (Leaf/Paper/Purpur) — it happens entirely inside the JDBC driver at connect time.

## Fix
Append `useInformationSchema=false` to the MySQL JDBC URL. The driver then uses its legacy metadata path (a hardcoded keyword list) instead of querying the MySQL-only `KEYWORDS` table. No behavioral change for real MySQL servers.

## Tested
Built and deployed on Paper 1.21.11 + MariaDB. Plugin now enables, schema creates, displays persist. (Verified against a live MariaDB instance where the unpatched build crashed on enable.)