### PR TITLE
Fix YouTube audio cutting out after ~10s

### DIFF
--- a/common/src/main/kotlin/com/dreamdisplays/media/DefaultStreamSelector.kt
+++ b/common/src/main/kotlin/com/dreamdisplays/media/DefaultStreamSelector.kt
@@ -18,6 +18,10 @@ class DefaultStreamSelector : StreamSelector {
         get() = System.getProperty("dreamdisplays.debug")?.toBoolean() == true
                 || System.getenv("DREAMDISPLAYS_DEBUG").let { it == "1" || it.equals("true", ignoreCase = true) }
 
+    // muxed progressive audio survives SABR; toggle with -Ddreamdisplays.audio.preferProgressive=false
+    private val preferProgressiveAudio: Boolean =
+        System.getProperty("dreamdisplays.audio.preferProgressive", "true").toBoolean()
+
     override fun select(streams: List<MediaStream>, preferences: StreamPreferences): StreamSet {
         val videoStreams = streams.filter { it.type.hasVideo }
         val audioStreams = streams.filter { it.type == MediaStreamType.AUDIO }
@@ -27,8 +31,12 @@ class DefaultStreamSelector : StreamSelector {
 
         val video = MediaStreamSelector.pickVideo(videoStreams, targetHeight, preferences.preferFps60)
             ?: videoStreams.firstOrNull()
-        val audio = MediaStreamSelector.pickAudio(audioStreams, lang, video)
+        val adaptiveAudio = MediaStreamSelector.pickAudio(audioStreams, lang, video)
             ?: audioStreams.firstOrNull()
+
+        val progressiveAudio = streams.filter { it.type == MediaStreamType.VIDEO_AUDIO }
+            .maxByOrNull { it.bitrate ?: 0 }
+        val audio = if (preferProgressiveAudio && progressiveAudio != null) progressiveAudio else adaptiveAudio
 
         if (debug) {
             logger.debug(

--- a/common/src/main/kotlin/com/dreamdisplays/media/DefaultStreamSelector.kt
+++ b/common/src/main/kotlin/com/dreamdisplays/media/DefaultStreamSelector.kt
@@ -18,7 +18,6 @@ class DefaultStreamSelector : StreamSelector {
         get() = System.getProperty("dreamdisplays.debug")?.toBoolean() == true
                 || System.getenv("DREAMDISPLAYS_DEBUG").let { it == "1" || it.equals("true", ignoreCase = true) }
 
-    // muxed progressive audio survives SABR; toggle with -Ddreamdisplays.audio.preferProgressive=false
     private val preferProgressiveAudio: Boolean =
         System.getProperty("dreamdisplays.audio.preferProgressive", "true").toBoolean()
 
@@ -41,7 +40,7 @@ class DefaultStreamSelector : StreamSelector {
         if (debug) {
             logger.debug(
                 "Video stream ${MediaStreamSelector.describeVideoChoice(video, targetHeight, preferences.preferFps60)} " +
-                        "candidates=${videoStreams.size} preferFps60=${preferences.preferFps60}",
+                        "candidates=${videoStreams.size} preferFps60=${preferences.preferFps60}.",
             )
         }
 

--- a/common/src/main/kotlin/com/dreamdisplays/player/pipeline/AudioSink.kt
+++ b/common/src/main/kotlin/com/dreamdisplays/player/pipeline/AudioSink.kt
@@ -394,11 +394,12 @@ internal class AudioSink(private val debugLabel: String) {
         return null
     }
 
-    /** Drains the audio process's stderr and logs anything ffmpeg emits (it runs at -loglevel error). */
+    /** Drains the audio process's stderr and logs each line FFmpeg emits as it arrives (it runs at -loglevel error). */
     private fun drainStderr(proc: Process) = daemon({
         try {
-            val text = proc.errorStream.bufferedReader().readText()
-            if (text.isNotBlank()) logger.warn("$debugLabel [audio] ffmpeg stderr: ${text.trim()}")
+            proc.errorStream.bufferedReader().forEachLine { line ->
+                if (line.isNotBlank()) logger.warn("$debugLabel [audio] FFmpeg stderr: ${line.trim()}.")
+            }
         } catch (_: IOException) {}
     }, "MediaPlayer-astderr").start()
 }

--- a/common/src/main/kotlin/com/dreamdisplays/player/pipeline/AudioSink.kt
+++ b/common/src/main/kotlin/com/dreamdisplays/player/pipeline/AudioSink.kt
@@ -7,7 +7,6 @@ import com.dreamdisplays.player.util.daemon
 import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.io.InputStream
-import java.io.OutputStream
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -307,13 +306,20 @@ internal class AudioSink(private val debugLabel: String) {
     private fun pumpLive(input: InputStream, ln: SourceDataLine, terminated: AtomicBoolean, stopFlag: AtomicBoolean) {
         val chunk = ByteArray(CHUNK_BYTES)
         var firstChunk = true
+        var totalBytes = 0L
         while (!terminated.get() && !stopFlag.get()) {
             if (parkIfRequested(ln, terminated, stopFlag)) break
             val n = MediaUtil.readFull(input, chunk, CHUNK_BYTES)
             if (n <= 0) {
-                if (firstChunk) logger.warn("$debugLabel [audio] no PCM data from ffmpeg (EOF on first read).")
+                if (firstChunk) {
+                    logger.warn("$debugLabel [audio] no PCM data from ffmpeg (EOF on first read).")
+                } else if (!terminated.get() && !stopFlag.get()) {
+                    val seconds = totalBytes / (SAMPLE_RATE * BYTES_PER_FRAME).toDouble()
+                    logger.warn("$debugLabel [audio] PCM stream ended after ${"%.1f".format(seconds)}s.")
+                }
                 break
             }
+            totalBytes += n
             if (firstChunk) { logger.debug("$debugLabel [audio] first PCM chunk received ($n bytes)."); firstChunk = false }
             ringPush(chunk, n) // Cache raw PCM (pre-volume) for the reappearance audio bridge
             MediaBufferEffects.applyVolumeS16LE(chunk, n, currentVolume)
@@ -388,8 +394,11 @@ internal class AudioSink(private val debugLabel: String) {
         return null
     }
 
-    /** Drains the process's stderr stream to /dev/null. */
+    /** Drains the audio process's stderr and logs anything ffmpeg emits (it runs at -loglevel error). */
     private fun drainStderr(proc: Process) = daemon({
-        try { proc.errorStream.transferTo(OutputStream.nullOutputStream()) } catch (_: IOException) {}
+        try {
+            val text = proc.errorStream.bufferedReader().readText()
+            if (text.isNotBlank()) logger.warn("$debugLabel [audio] ffmpeg stderr: ${text.trim()}")
+        } catch (_: IOException) {}
     }, "MediaPlayer-astderr").start()
 }

--- a/common/src/main/kotlin/com/dreamdisplays/player/process/MediaProcess.kt
+++ b/common/src/main/kotlin/com/dreamdisplays/player/process/MediaProcess.kt
@@ -124,6 +124,8 @@ object MediaProcess {
                     "-reconnect_delay_max", "10",
                     "-reconnect_on_network_error", "1",
                     "-reconnect_on_http_error", "4xx,5xx",
+                    // pull googlevideo over one connection with range requests so it doesn't cut at ~10s
+                    "-multiple_requests", "1",
                 )
             )
             addAll(listOf("-rw_timeout", "15000000"))

--- a/common/src/main/kotlin/com/dreamdisplays/player/stream/MediaStreamSelector.kt
+++ b/common/src/main/kotlin/com/dreamdisplays/player/stream/MediaStreamSelector.kt
@@ -43,8 +43,8 @@ object MediaStreamSelector {
     internal fun switchQuality(streams: ActiveStreams, target: Int, lang: String): ActiveStreams? {
         val best = pickVideo(streams.availableVideo, target)
             ?.takeIf { it.url != streams.currentVideo.url } ?: return null
-        val audio = pickAudio(streams.availableAudio, lang, best) ?: streams.currentAudio
-        return streams.copy(currentVideo = best, currentAudio = audio)
+        // keep the current audio so the progressive pick isn't reverted on a quality switch
+        return streams.copy(currentVideo = best, currentAudio = streams.currentAudio)
     }
 
     /** Pick the best video stream closest to [target] quality (height in pixels). */


### PR DESCRIPTION
### Problem

YouTube audio would cut out roughly ~10 seconds into playback. The cause is that YouTube serves the adaptive (audio-only) track over SABR, which ffmpeg can only pull briefly before the server closes the connection.

### Fix

- **Prefer the muxed progressive stream for audio when one is available** — it survives SABR. Can be toggled off with `-Ddreamdisplays.audio.preferProgressive=false`.
- **Keep that audio choice on quality switches** so the progressive pick isn't reverted mid-playback.
- **Add ffmpeg `-multiple_requests 1`** so the googlevideo stream is pulled over a single persistent connection with range requests instead of cutting at ~10s.
- **Log ffmpeg stderr and stream-end** (with elapsed seconds) so future cutoffs are actually visible instead of being silently drained to null.

### Files touched

- `common/.../media/DefaultStreamSelector.kt`
- `common/.../player/pipeline/AudioSink.kt`
- `common/.../player/process/MediaProcess.kt`
- `common/.../player/stream/MediaStreamSelector.kt`

### Testing

Verified locally that YouTube audio now plays through past the ~10s mark and survives quality switches.
